### PR TITLE
parsing import statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 .tox
 .coverage
+testing

--- a/src/interpreted/nodes.py
+++ b/src/interpreted/nodes.py
@@ -175,5 +175,22 @@ class Return(Statement):
 
 
 @dataclass
+class alias(Statement):
+    name: str
+    asname: str | None
+
+
+@dataclass
+class Import(Statement):
+    names: list[alias]
+
+
+@dataclass
+class ImportFrom(Statement):
+    module: str | None
+    names: list[alias]
+
+
+@dataclass
 class Module:
     body: list[Statement]

--- a/src/interpreted/parser.py
+++ b/src/interpreted/parser.py
@@ -62,7 +62,12 @@ class Parser:
         While -> 'while' expression ':' block [else]
         For -> 'for' targets 'in' expressions ':' block else?
         targets -> primary (',' primary)* ','?
+<<<<<<< HEAD
         single_line_stmt -> Import | ImportFrom | Pass | Break | Continue | Return | Assign | ExprStmt
+=======
+        single_line_stmt -> ImportStmt | Pass | Break | Continue | Return | Assign | ExprStmt
+        ImportStmt -> Import | ImportFrom
+>>>>>>> da9c92a (update grammar docstring)
         Import -> 'import' module ('as' alias)? (',' module ('as' alias)? )* '\n'
         ImportFrom -> 'from' module 'import' NAME ('as' alias)? (',' NAME 'as' alias)? '\n'
         module -> NAME ('.' NAME)*


### PR DESCRIPTION
`as` is parsed using the `parse_expressions()` chain, returned to `parse_import()` as a `BinaryOp` type. Nodes `Import`, `ImportFrom` and `alias` are used to represent imports.