### PR TITLE
Handle unicode escapes

### DIFF
--- a/src/interpreted/interpreter.py
+++ b/src/interpreted/interpreter.py
@@ -267,7 +267,47 @@ class Value(Object):
         return f"Value({self.value!r})"
 
     def as_string(self) -> None:
-        return str(self.value)
+        if not isinstance(self.value, str):
+            return str(self.value)
+
+        transformed_chars = []
+        index = 0
+        while index < len(self.value):
+            char = self.value[index]
+            if char != "\\":
+                transformed_chars.append(char)
+                index += 1
+            else:
+                next_char = self.value[index + 1]
+                if next_char == "x":
+                    next_four_chars = self.value[index + 2 : index + 4]
+                    try:
+                        unicode_char = chr(int(next_four_chars, 16))
+                        transformed_chars.append(unicode_char)
+                    except ValueError:
+                        transformed_chars.extend(["\\", "x"])
+                    index += 4
+                elif next_char == "u":
+                    next_four_chars = self.value[index + 2 : index + 6]
+                    try:
+                        unicode_char = chr(int(next_four_chars, 16))
+                        transformed_chars.append(unicode_char)
+                    except ValueError:
+                        transformed_chars.extend(["\\", "u"])
+                    index += 6
+                elif next_char == "U":
+                    next_eight_chars = self.value[index + 2 : index + 10]
+                    try:
+                        unicode_char = chr(int(next_eight_chars, 16))
+                        transformed_chars.append(unicode_char)
+                    except ValueError:
+                        transformed_chars.extend(["\\", "U"])
+                    index += 10
+                else:
+                    transformed_chars.extend(["\\", next_char])
+                    index += 2
+
+        return "".join(transformed_chars)
 
     def repr(self) -> None:
         return repr(self.value)

--- a/src/interpreted/interpreter.py
+++ b/src/interpreted/interpreter.py
@@ -280,32 +280,25 @@ class Value(Object):
             else:
                 next_char = self.value[index + 1]
                 if next_char == "x":
-                    next_four_chars = self.value[index + 2 : index + 4]
-                    try:
-                        unicode_char = chr(int(next_four_chars, 16))
-                        transformed_chars.append(unicode_char)
-                    except ValueError:
-                        transformed_chars.extend(["\\", "x"])
+                    chars = self.value[index + 2 : index + 4]
                     index += 4
                 elif next_char == "u":
-                    next_four_chars = self.value[index + 2 : index + 6]
-                    try:
-                        unicode_char = chr(int(next_four_chars, 16))
-                        transformed_chars.append(unicode_char)
-                    except ValueError:
-                        transformed_chars.extend(["\\", "u"])
+                    chars = self.value[index + 2 : index + 6]
                     index += 6
                 elif next_char == "U":
-                    next_eight_chars = self.value[index + 2 : index + 10]
-                    try:
-                        unicode_char = chr(int(next_eight_chars, 16))
-                        transformed_chars.append(unicode_char)
-                    except ValueError:
-                        transformed_chars.extend(["\\", "U"])
+                    chars = self.value[index + 2 : index + 10]
                     index += 10
                 else:
                     transformed_chars.extend(["\\", next_char])
                     index += 2
+
+                try:
+                    unicode_char = chr(int(chars, 16))
+                    transformed_chars.append(unicode_char)
+                except ValueError as exc:
+                    raise InterpreterError(
+                        f"Invalid unicode escape: \\{next_char}{chars}"
+                    ) from exc
 
         return "".join(transformed_chars)
 

--- a/src/interpreted/parser.py
+++ b/src/interpreted/parser.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import ast
 from keyword import iskeyword
 
 import sys
@@ -534,9 +533,9 @@ class Parser:
 
         if self.match_type(TokenType.STRING):
             token = self.current()
-            unquoted_unescaped_string = ast.literal_eval(token.string)
-            assert isinstance(unquoted_unescaped_string, str)
-            return Constant(unquoted_unescaped_string)
+            unquoted_string = unquote(token.string)
+            assert isinstance(unquoted_string, str)
+            return Constant(unquoted_string)
 
         if self.match_op("("):
             # special_case: no items
@@ -596,6 +595,24 @@ def parse(source: str) -> Module | None:
         line, column = index_to_line_column(token.start, source)
         print(f"Parse Error at {line}:{column} -", exc)
         return
+
+
+def unquote(string: str) -> str:
+    if len(string) == 1:
+        return string
+
+    first, last = string[0], string[-1]
+    if first not in ("'", '"'):
+        return string
+
+    if first != last:
+        return string
+
+    first_three, last_three = string[:3], string[-3:]
+    if first_three == last_three:
+        return string[3:-3]
+
+    return string[1:-1]
 
 
 def main() -> None:

--- a/src/interpreted/tokenizer.py
+++ b/src/interpreted/tokenizer.py
@@ -238,7 +238,7 @@ class Tokenizer:
             if next_char == "":
                 raise TokenizeError("Unterminated string", index=self.start)
 
-            if next_char in "\nnrtf'\"\\":
+            if next_char in "\nnrtxuUf'\"\\":
                 continue
 
             # Not implemented: \xHH, \uHHHH and \UHHHHHHHH

--- a/tests/interpreted_test.py
+++ b/tests/interpreted_test.py
@@ -10,12 +10,13 @@ import pytest
     ("source", "output"),
     (
         ("print('hello!')", "hello!\n"),
+        ('print("""foo""")', "foo\n"),
         (r"print('foo \x41 bar')", "foo A bar\n"),
         (r"print('foo \u1234 bar')", "foo ሴ bar\n"),
         (r"print('foo \u2603 bar')", "foo ☃ bar\n"),
         (r"print('foo \U00002603 bar')", "foo ☃ bar\n"),
         (r"print('foo \U0001F643 bar')", "foo 🙃 bar\n"),
-        (r"print('foo \x41 \U0001F643 bar')", "foo A 🙃 bar\n"), 
+        (r"print('foo \x41 \U0001F643 bar')", "foo A 🙃 bar\n"),
         (
             """\
             def foo(x):

--- a/tests/interpreted_test.py
+++ b/tests/interpreted_test.py
@@ -10,6 +10,12 @@ import pytest
     ("source", "output"),
     (
         ("print('hello!')", "hello!\n"),
+        (r"print('foo \x41 bar')", "foo A bar\n"),
+        (r"print('foo \u1234 bar')", "foo ሴ bar\n"),
+        (r"print('foo \u2603 bar')", "foo ☃ bar\n"),
+        (r"print('foo \U00002603 bar')", "foo ☃ bar\n"),
+        (r"print('foo \U0001F643 bar')", "foo 🙃 bar\n"),
+        (r"print('foo \x41 \U0001F643 bar')", "foo A 🙃 bar\n"), 
         (
             """\
             def foo(x):


### PR DESCRIPTION
- Instead of relying on `ast.literal_eval`, we now manually handle unicode escapes.
- Since `ast.literal_eval` was removed, we have to manually unquote the string as well before making it a `Constant` node.

Resolves #8 