### PR TITLE
parsing import statements

### DIFF
--- a/src/interpreted/nodes.py
+++ b/src/interpreted/nodes.py
@@ -175,5 +175,22 @@ class Return(Statement):
 
 
 @dataclass
+class alias:
+    name: str
+    asname: str | None
+
+
+@dataclass
+class Import(Statement):
+    names: list[alias]
+
+
+@dataclass
+class ImportFrom(Statement):
+    module: str
+    names: list[alias]
+
+
+@dataclass
 class Module:
     body: list[Statement]

--- a/src/interpreted/parser.py
+++ b/src/interpreted/parser.py
@@ -317,10 +317,6 @@ class Parser:
         names = []
         module = self.current().string
 
-        # case: import single module
-        if self.peek().token_type in (TokenType.NEWLINE, TokenType.EOF):
-            return Import(names=[alias(name=module, asname=None)])
-
         while True:
             if self.match_op(","):
                 self.expect(TokenType.NAME)
@@ -359,6 +355,8 @@ class Parser:
         # parse submodule names or direct import keyword
         if self.match_op("."):
             while not self.match_name("import"):
+                if self.match_op("."):
+                    continue
                 self.expect(TokenType.NAME)
                 module_name += "." + self.current().string
 
@@ -381,9 +379,8 @@ class Parser:
                 self.expect(TokenType.NAME)
                 names.append(alias(name=name, asname=None))
                 name = self.current().string
-                continue
 
-            elif self.match_name("as"):
+            if self.match_name("as"):
                 self.expect(TokenType.NAME)
                 alias_name = self.current().string
                 names.append(alias(name=name, asname=alias_name))
@@ -392,7 +389,6 @@ class Parser:
                 elif self.match_op(","):
                     self.expect(TokenType.NAME)
                     name = self.current().string
-                continue
 
             if self.peek().token_type in (TokenType.NEWLINE, TokenType.EOF):
                 names.append(alias(name=name, asname=None))

--- a/src/interpreted/parser.py
+++ b/src/interpreted/parser.py
@@ -62,7 +62,9 @@ class Parser:
         While -> 'while' expression ':' block [else]
         For -> 'for' targets 'in' expressions ':' block else?
         targets -> primary (',' primary)* ','?
-        single_line_stmt -> Pass | Break | Continue | Return | Assign | ExprStmt
+        single_line_stmt -> Pass | Break | Continue | Return | Assign | ExprStmt | Import | ImportFrom
+        Import -> 'import' module ('as' alias)? (',' module ('as' alias)? )* '\n'
+        ImportFrom -> 'from' module 'import' NAME ('as' alias)? (',' NAME ('as' alias)?)* '\n'
         Pass -> 'pass' '\n'
         Return -> 'return' expressions? '\n'
         expressions -> expression (',' expression)* ','?
@@ -274,7 +276,7 @@ class Parser:
 
     def parse_single_line_statement(
         self,
-    ) -> Pass | Break | Continue | Return | Assign | ExprStmt:
+    ) -> Pass | Break | Continue | Return | Assign | ExprStmt | Import | ImportFrom:
         if self.match_name("pass"):
             node = Pass()
 

--- a/src/interpreted/parser.py
+++ b/src/interpreted/parser.py
@@ -327,7 +327,7 @@ class Parser:
                 module = self.current().string
                 continue
 
-            elif self.match_name("as"):
+            if self.match_name("as"):
                 self.expect(TokenType.NAME)
                 alias_name = self.current().string
                 names.append(alias(name=module, asname=alias_name))

--- a/src/interpreted/parser.py
+++ b/src/interpreted/parser.py
@@ -355,14 +355,11 @@ class Parser:
         names = []
 
         # parse submodule names or direct import keyword
-        if self.match_op("."):
-            while not self.match_name("import"):
-                if self.match_op("."):
-                    continue
-                self.expect(TokenType.NAME)
-                module_name += "." + self.current().string
+        while self.match_op("."):
+            self.expect(TokenType.NAME)
+            module_name += "." + self.current().string
 
-        elif not self.match_name("import"):
+        if not self.match_name("import"):
             raise ParseError("Expected 'import' keyword", self.index)
 
         # case: import all

--- a/src/interpreted/parser.py
+++ b/src/interpreted/parser.py
@@ -63,8 +63,9 @@ class Parser:
         For -> 'for' targets 'in' expressions ':' block else?
         targets -> primary (',' primary)* ','?
         single_line_stmt -> Pass | Break | Continue | Return | Assign | ExprStmt | Import | ImportFrom
-        Import -> 'import' module ('as' alias)? (',' module ('as' alias)? )* '\n'
-        ImportFrom -> 'from' module 'import' NAME ('as' alias)? (',' NAME ('as' alias)?)* '\n'
+        ImportFrom -> 'from' module 'import' alias (',' alias)* '\n'
+        alias -> NAME ('as' NAME)?
+        module -> NAME ('.' NAME)*
         Pass -> 'pass' '\n'
         Return -> 'return' expressions? '\n'
         expressions -> expression (',' expression)* ','?

--- a/src/interpreted/parser.py
+++ b/src/interpreted/parser.py
@@ -34,7 +34,7 @@ from interpreted.nodes import (
     While,
     Import,
     ImportFrom,
-    alias
+    alias,
 )
 from interpreted.tokenizer import EOF, Token, TokenType, index_to_line_column, tokenize
 
@@ -295,7 +295,7 @@ class Parser:
             # TODO: make it a tuple if > 1
             assert len(return_values) == 1
             node = Return(value=return_values[0])
-        
+
         # Now here we come to a conundrum.
         # Assign expects `targets`, and ExprStmt expects `expressions`, and `targets`
         # is a restricted version of `expressions`.
@@ -319,23 +319,19 @@ class Parser:
 
         # case: import single module
         if self.peek().token_type in (TokenType.NEWLINE, TokenType.EOF):
-            return Import(names=[alias(name=module,asname=None)])
+            return Import(names=[alias(name=module, asname=None)])
 
         while True:
             if self.match_op(","):
                 self.expect(TokenType.NAME)
-                names.append(
-                    alias(name=module, asname=None)
-                )
+                names.append(alias(name=module, asname=None))
                 module = self.current().string
                 continue
 
             elif self.match_name("as"):
                 self.expect(TokenType.NAME)
                 alias_name = self.current().string
-                names.append(
-                    alias(name=module, asname=alias_name)
-                )
+                names.append(alias(name=module, asname=alias_name))
                 if self.peek().token_type in (TokenType.NEWLINE, TokenType.EOF):
                     break
                 elif self.match_op(","):
@@ -343,19 +339,16 @@ class Parser:
                     module = self.current().string
                 continue
 
-            if self.match_op('.'):
+            if self.match_op("."):
                 self.expect(TokenType.NAME)
-                module += '.' + self.current().string
+                module += "." + self.current().string
                 continue
 
             if self.peek().token_type in (TokenType.NEWLINE, TokenType.EOF):
-                names.append(
-                    alias(name=module, asname=None)
-                )
+                names.append(alias(name=module, asname=None))
                 break
 
         return Import(names=names)
-
 
     def parse_importfrom(self) -> ImportFrom:
         self.expect(TokenType.NAME)
@@ -367,17 +360,14 @@ class Parser:
         if self.match_op("."):
             while not self.match_name("import"):
                 self.expect(TokenType.NAME)
-                module_name += '.' + self.current().string
+                module_name += "." + self.current().string
 
         elif not self.match_name("import"):
             raise ParseError("Expected 'import' keyword", self.index)
 
         # case: import all
         if self.match_op("*"):
-            return ImportFrom(
-                module=module_name,
-                names=[alias(name="*", asname=None)]
-            )
+            return ImportFrom(module=module_name, names=[alias(name="*", asname=None)])
 
         self.expect(TokenType.NAME)
         name = self.current().string
@@ -389,18 +379,14 @@ class Parser:
         while True:
             if self.match_op(","):
                 self.expect(TokenType.NAME)
-                names.append(
-                    alias(name=name, asname=None)
-                )
+                names.append(alias(name=name, asname=None))
                 name = self.current().string
                 continue
 
             elif self.match_name("as"):
                 self.expect(TokenType.NAME)
                 alias_name = self.current().string
-                names.append(
-                    alias(name=name, asname=alias_name)
-                )
+                names.append(alias(name=name, asname=alias_name))
                 if self.peek().token_type in (TokenType.NEWLINE, TokenType.EOF):
                     break
                 elif self.match_op(","):
@@ -409,13 +395,10 @@ class Parser:
                 continue
 
             if self.peek().token_type in (TokenType.NEWLINE, TokenType.EOF):
-                names.append(
-                    alias(name=name, asname=None)
-                )
+                names.append(alias(name=name, asname=None))
                 break
 
         return ImportFrom(module=module_name, names=names)
-
 
     def parse_assign_or_exprstmt(self) -> Assign | ExprStmt:
         expressions = self.parse_expressions()

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -94,6 +94,7 @@ from interpreted.tokenizer import Tokenizer
             from module_name import name1, name2
             from module_name import name1 as alias1, name2 as alias2
             from package_name.submodule import submodule_name
+            from mod.submod.meh import ara as a, b as aux
             """,
             Module(
                 body=[
@@ -117,6 +118,13 @@ from interpreted.tokenizer import Tokenizer
                     ImportFrom(
                         module="package_name.submodule",
                         names=[alias(name="submodule_name", asname=None)],
+                    ),
+                    ImportFrom(
+                        module="mod.submod.meh",
+                        names=[
+                            alias(name="ara", asname="a"),
+                            alias(name="b", asname="aux"),
+                        ],
                     ),
                 ]
             ),

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -14,7 +14,7 @@ from interpreted.nodes import (
     While,
     Import,
     ImportFrom,
-    alias
+    alias,
 )
 from interpreted.parser import Parser
 from interpreted.tokenizer import Tokenizer
@@ -69,17 +69,23 @@ from interpreted.tokenizer import Tokenizer
             """,
             Module(
                 body=[
-                    Import(names=[alias(name='ast', asname=None), alias(name='mod', asname=None)]),
-                    Import(names=[alias(name='module_name', asname=None)]),
-                    Import(names=[
-                        alias(name='module_name', asname='alias'),
-                        alias(name='othername', asname='other_alias')
-                    ]),
-                    Import(names=[alias(name='package_name.module_name', asname=None)])
+                    Import(
+                        names=[
+                            alias(name="ast", asname=None),
+                            alias(name="mod", asname=None),
+                        ]
+                    ),
+                    Import(names=[alias(name="module_name", asname=None)]),
+                    Import(
+                        names=[
+                            alias(name="module_name", asname="alias"),
+                            alias(name="othername", asname="other_alias"),
+                        ]
+                    ),
+                    Import(names=[alias(name="package_name.module_name", asname=None)]),
                 ]
-            )            
+            ),
         ),
-
         (
             """\
             from module_name import *
@@ -90,30 +96,29 @@ from interpreted.tokenizer import Tokenizer
             Module(
                 body=[
                     ImportFrom(
-                        module='module_name',
-                        names=[alias(name='*', asname=None)]
+                        module="module_name", names=[alias(name="*", asname=None)]
                     ),
                     ImportFrom(
-                        module='module_name',
+                        module="module_name",
                         names=[
-                            alias(name='name1', asname=None),
-                            alias(name='name2', asname=None)
-                        ]
+                            alias(name="name1", asname=None),
+                            alias(name="name2", asname=None),
+                        ],
                     ),
                     ImportFrom(
-                        module='module_name',
+                        module="module_name",
                         names=[
-                            alias(name='name1', asname='alias1'),
-                            alias(name='name2', asname='alias2')
-                        ]
+                            alias(name="name1", asname="alias1"),
+                            alias(name="name2", asname="alias2"),
+                        ],
                     ),
                     ImportFrom(
-                        module='package_name.submodule',
-                        names=[alias(name='submodule_name', asname=None)]
-                    )
+                        module="package_name.submodule",
+                        names=[alias(name="submodule_name", asname=None)],
+                    ),
                 ]
-            )            
-        )
+            ),
+        ),
     ),
 )
 def test_parser(source: str, tree: Module) -> None:

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -66,6 +66,7 @@ from interpreted.tokenizer import Tokenizer
             import module_name
             import module_name as alias, othername as other_alias
             import package_name.module_name
+            import a.b.c
             """,
             Module(
                 body=[
@@ -83,6 +84,7 @@ from interpreted.tokenizer import Tokenizer
                         ]
                     ),
                     Import(names=[alias(name="package_name.module_name", asname=None)]),
+                    Import(names=[alias(name="a.b.c", asname=None)]),
                 ]
             ),
         ),

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -12,6 +12,9 @@ from interpreted.nodes import (
     Module,
     Name,
     While,
+    Import,
+    ImportFrom,
+    alias
 )
 from interpreted.parser import Parser
 from interpreted.tokenizer import Tokenizer
@@ -57,6 +60,60 @@ from interpreted.tokenizer import Tokenizer
                 ],
             ),
         ),
+        (
+            """\
+            import ast, mod
+            import module_name
+            import module_name as alias, othername as other_alias
+            import package_name.module_name
+            """,
+            Module(
+                body=[
+                    Import(names=[alias(name='ast', asname=None), alias(name='mod', asname=None)]),
+                    Import(names=[alias(name='module_name', asname=None)]),
+                    Import(names=[
+                        alias(name='module_name', asname='alias'),
+                        alias(name='othername', asname='other_alias')
+                    ]),
+                    Import(names=[alias(name='package_name.module_name', asname=None)])
+                ]
+            )            
+        ),
+
+        (
+            """\
+            from module_name import *
+            from module_name import name1, name2
+            from module_name import name1 as alias1, name2 as alias2
+            from package_name.submodule import submodule_name
+            """,
+            Module(
+                body=[
+                    ImportFrom(
+                        module='module_name',
+                        names=[alias(name='*', asname=None)]
+                    ),
+                    ImportFrom(
+                        module='module_name',
+                        names=[
+                            alias(name='name1', asname=None),
+                            alias(name='name2', asname=None)
+                        ]
+                    ),
+                    ImportFrom(
+                        module='module_name',
+                        names=[
+                            alias(name='name1', asname='alias1'),
+                            alias(name='name2', asname='alias2')
+                        ]
+                    ),
+                    ImportFrom(
+                        module='package_name.submodule',
+                        names=[alias(name='submodule_name', asname=None)]
+                    )
+                ]
+            )            
+        )
     ),
 )
 def test_parser(source: str, tree: Module) -> None:


### PR DESCRIPTION
Import logic is now handled inside the `parse_import` and `parse_importfrom` functions.

Removed `parse_as()` from `parser.py` and `testing` from `.gitignore` as requested in PR #15 