### PR TITLE
imports implementation

### DIFF
--- a/src/interpreted/interpreter.py
+++ b/src/interpreted/interpreter.py
@@ -17,6 +17,8 @@ from interpreted.nodes import (
     ExprStmt,
     FunctionDef,
     If,
+    Import,
+    ImportFrom,
     Module,
     Name,
     Node,
@@ -25,8 +27,6 @@ from interpreted.nodes import (
     UnaryOp,
     While,
     alias,
-    Import,
-    ImportFrom,
 )
 from interpreted.parser import parse
 

--- a/src/interpreted/interpreter.py
+++ b/src/interpreted/interpreter.py
@@ -66,7 +66,7 @@ class Object:
         return self.as_string()
 
 
-class ModuleObj(Object):
+class Module(Object):
     def __init__(self, attrs: {str: Scope}):
         self.attributes = attrs
 
@@ -423,7 +423,7 @@ class Interpreter:
             self.scope = parent_scope
             self.globals = parent_globals
 
-            module_obj = ModuleObj(attrs=vars(module_scope))
+            module_obj = Module(attrs=vars(module_scope))
 
             self.scope.set(name, module_obj)
 

--- a/tests/interpreted_test.py
+++ b/tests/interpreted_test.py
@@ -118,8 +118,11 @@ def test_imports(tmp_path) -> None:
         def area(r):
             return PI * r * r
     """
+    smth_content = """\
+        from calc import *
+    """
     utils_content = """\
-        import calc as math
+        import smth as math
 
         def cos(x):
             return "bru what"
@@ -141,6 +144,9 @@ def test_imports(tmp_path) -> None:
 
     math = tmp_path / "calc.py"
     math.write_text(dedent(math_content))
+
+    smth = tmp_path / "smth.py"
+    smth.write_text(dedent(smth_content))
 
     process = subprocess.run(
         ["interpreted", main.as_posix()],

--- a/tests/interpreted_test.py
+++ b/tests/interpreted_test.py
@@ -120,15 +120,19 @@ def test_imports(tmp_path) -> None:
     """
     smth_content = """\
         from calc import *
+        def add2():
+            return add(2, 2)
     """
     utils_content = """\
         import smth as math
 
         def cos(x):
+            print(math.add2())
             return "bru what"
     """
     main_content = """\
         from utils import math, cos
+        import smth
 
         print(math.area(2))
         print(math.add(2,3))
@@ -156,5 +160,5 @@ def test_imports(tmp_path) -> None:
     )
 
     assert process.stderr == b""
-    assert process.stdout.decode() == "12.56\n5\n12\nbru what\n"
+    assert process.stdout.decode() == "12.56\n5\n12\n4\nbru what\n"
     assert process.returncode == 0


### PR DESCRIPTION
~~No tests for now.~~

Direct import statements are handled by associating names with a scope object.

`from` imports use a `scope_lookup` that is used to load the relevant scope for a node, defined for a `Scope` object, thus keeping them isolated. `Value` types are not added to the lookup.

Resolves #13 (probably)